### PR TITLE
Add Excel VBA regression CI

### DIFF
--- a/.github/workflows/excel-vba-regression.yml
+++ b/.github/workflows/excel-vba-regression.yml
@@ -1,0 +1,62 @@
+name: Excel VBA Regression
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "ci/**"
+      - ".github/workflows/excel-vba-regression.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "ci/**"
+      - ".github/workflows/excel-vba-regression.yml"
+
+concurrency:
+  group: excel-vba-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    name: Run Excel/VBA regression harness
+
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+      - excel
+
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run complete VBA regression suite through Excel COM
+        shell: pwsh
+        run: >-
+          ./ci/Run-ExcelVbaTests.ps1
+          -RepositoryRoot "${{ github.workspace }}"
+
+      - name: Upload VBA test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: excel-vba-regression-${{ github.run_id }}
+          path: artifacts/excel-vba-ci/test-result.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/ci/Run-ExcelVbaTests.ps1
+++ b/ci/Run-ExcelVbaTests.ps1
@@ -11,6 +11,10 @@ $ErrorActionPreference = "Stop"
 
 $excel = $null
 $workbook = $null
+$vbProject = $null
+$testComponent = $null
+$codeModule = $null
+
 $workbookPath = Join-Path $ArtifactDirectory "VBA_Probability_Distributions_CI.xlsm"
 $resultPath = Join-Path $ArtifactDirectory "test-result.txt"
 
@@ -34,6 +38,10 @@ function Release-ComObjectSafely {
 try {
     New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
     Set-Content -LiteralPath $resultPath -Value "" -Encoding UTF8
+
+    if (Test-Path -LiteralPath $workbookPath) {
+        Remove-Item -LiteralPath $workbookPath -Force
+    }
 
     Write-CiLog "Repository root: $RepositoryRoot"
     Write-CiLog "Creating isolated Excel workbook for VBA regression execution."

--- a/ci/Run-ExcelVbaTests.ps1
+++ b/ci/Run-ExcelVbaTests.ps1
@@ -1,0 +1,216 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ArtifactDirectory = (Join-Path $RepositoryRoot "artifacts\excel-vba-ci")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$excel = $null
+$workbook = $null
+$workbookPath = Join-Path $ArtifactDirectory "VBA_Probability_Distributions_CI.xlsm"
+$resultPath = Join-Path $ArtifactDirectory "test-result.txt"
+
+function Write-CiLog {
+    param([string]$Message)
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $line = "[$timestamp] $Message"
+    Write-Host $line
+    Add-Content -LiteralPath $resultPath -Value $line -Encoding UTF8
+}
+
+function Release-ComObjectSafely {
+    param([object]$ComObject)
+
+    if ($null -ne $ComObject -and [System.Runtime.InteropServices.Marshal]::IsComObject($ComObject)) {
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($ComObject)
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
+    Set-Content -LiteralPath $resultPath -Value "" -Encoding UTF8
+
+    Write-CiLog "Repository root: $RepositoryRoot"
+    Write-CiLog "Creating isolated Excel workbook for VBA regression execution."
+
+    $sourceFiles = @(
+        "src\M_STATS_PROBDIST_CORE.bas",
+        "src\M_STATS_PROBDIST_SPECIALFUNCS.bas",
+        "src\M_STATS_PROBDIST_NORMALFAMILY.bas",
+        "src\M_STATS_PROBDIST_TFAMILY.bas",
+        "src\M_STATS_PROBDIST_CONTINUOUS.bas",
+        "tests\M_STATS_PROBDIST_TEST.bas"
+    )
+
+    foreach ($relativePath in $sourceFiles) {
+        $absolutePath = Join-Path $RepositoryRoot $relativePath
+        if (-not (Test-Path -LiteralPath $absolutePath -PathType Leaf)) {
+            throw "Required VBA module not found: $relativePath"
+        }
+    }
+
+    $excel = New-Object -ComObject Excel.Application
+    $excel.Visible = $false
+    $excel.DisplayAlerts = $false
+    $excel.EnableEvents = $false
+    $excel.ScreenUpdating = $false
+
+    # msoAutomationSecurityLow = 1. This applies only to the isolated Excel
+    # instance created by this script. The runner must still allow trusted
+    # programmatic access to the VBA project object model.
+    $excel.AutomationSecurity = 1
+
+    Write-CiLog ("Excel version: " + $excel.Version)
+    Write-CiLog ("Excel build: " + $excel.Build)
+
+    $workbook = $excel.Workbooks.Add()
+    $workbook.SaveAs($workbookPath, 52) # xlOpenXMLWorkbookMacroEnabled
+
+    try {
+        $vbProject = $workbook.VBProject
+    }
+    catch {
+        throw @"
+Excel denied programmatic access to the VBA project object model.
+On the self-hosted runner, open Excel and enable:
+File > Options > Trust Center > Trust Center Settings > Macro Settings >
+Trust access to the VBA project object model.
+Original error: $($_.Exception.Message)
+"@
+    }
+
+    foreach ($relativePath in $sourceFiles) {
+        $absolutePath = Join-Path $RepositoryRoot $relativePath
+        Write-CiLog "Importing $relativePath"
+        [void]$vbProject.VBComponents.Import($absolutePath)
+    }
+
+    $testComponent = $vbProject.VBComponents.Item("M_STATS_PROBDIST_TEST")
+    $codeModule = $testComponent.CodeModule
+
+    # Inject the CI bridge into the same module as the private counters and suite
+    # drivers. It is not committed to the production .bas file and exists only
+    # in this temporary workbook.
+    $ciBridge = @'
+
+Public Function Test_STATS_PROBDIST_RunAll_CI() As String
+'
+'==============================================================================
+' Test_STATS_PROBDIST_RunAll_CI
+'------------------------------------------------------------------------------
+' PURPOSE
+'   Executes the complete regression suite and returns machine-readable counters
+'   to the PowerShell/COM GitHub Actions runner.
+'
+' NOTES
+'   This procedure is injected at CI runtime into M_STATS_PROBDIST_TEST so it can
+'   read the module-private assertion counters without widening their production
+'   scope.
+'==============================================================================
+'
+    On Error GoTo Err_Handler
+
+    BeginRun "ALL SUITES - GITHUB ACTIONS"
+    RunCoreSuite
+    RunNormalFamilySuite
+    RunTFamilySuite
+    RunContinuousSuite
+    EndRun
+
+    Test_STATS_PROBDIST_RunAll_CI = _
+        "TOTAL=" & CStr(mTestCount) & _
+        ";PASS=" & CStr(mPassCount) & _
+        ";FAIL=" & CStr(mFailCount)
+    Exit Function
+
+Err_Handler:
+    Test_STATS_PROBDIST_RunAll_CI = _
+        "ERROR=" & CStr(Err.Number) & ";DESCRIPTION=" & Err.Description
+End Function
+'@
+
+    $insertLine = $codeModule.CountOfLines + 1
+    $codeModule.InsertLines($insertLine, $ciBridge)
+
+    $workbook.Save()
+    Write-CiLog "Executing Test_STATS_PROBDIST_RunAll_CI"
+
+    $macroName = "'" + $workbook.Name + "'!Test_STATS_PROBDIST_RunAll_CI"
+    $rawResult = [string]$excel.Run($macroName)
+    Write-CiLog "VBA result: $rawResult"
+
+    if ($rawResult -match '^ERROR=(-?\d+);DESCRIPTION=(.*)$') {
+        throw "The VBA test entry point raised error $($Matches[1]): $($Matches[2])"
+    }
+
+    if ($rawResult -notmatch '^TOTAL=(\d+);PASS=(\d+);FAIL=(\d+)$') {
+        throw "Unexpected machine-readable VBA result: $rawResult"
+    }
+
+    $total = [int]$Matches[1]
+    $passed = [int]$Matches[2]
+    $failed = [int]$Matches[3]
+
+    Write-CiLog "Assertions executed: $total"
+    Write-CiLog "Assertions passed: $passed"
+    Write-CiLog "Assertions failed: $failed"
+
+    if ($total -le 0) {
+        throw "The VBA harness reported zero executed assertions."
+    }
+
+    if (($passed + $failed) -ne $total) {
+        throw "Inconsistent VBA counters: PASS + FAIL does not equal TOTAL."
+    }
+
+    if ($failed -gt 0) {
+        Write-CiLog "RESULT: TEST FAILURE"
+        exit 1
+    }
+
+    Write-CiLog "RESULT: ALL TESTS PASSED"
+    exit 0
+}
+catch {
+    $message = $_.Exception.Message
+    Write-CiLog "RESULT: CI EXECUTION ERROR"
+    Write-CiLog $message
+    Write-Error $message
+    exit 1
+}
+finally {
+    if ($null -ne $workbook) {
+        try {
+            $workbook.Close($false)
+        }
+        catch {
+            Write-Warning "Unable to close the temporary workbook cleanly: $($_.Exception.Message)"
+        }
+    }
+
+    if ($null -ne $excel) {
+        try {
+            $excel.DisplayAlerts = $false
+            $excel.Quit()
+        }
+        catch {
+            Write-Warning "Unable to quit Excel cleanly: $($_.Exception.Message)"
+        }
+    }
+
+    Release-ComObjectSafely $codeModule
+    Release-ComObjectSafely $testComponent
+    Release-ComObjectSafely $vbProject
+    Release-ComObjectSafely $workbook
+    Release-ComObjectSafely $excel
+
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+}

--- a/docs/EXCEL_VBA_CI.md
+++ b/docs/EXCEL_VBA_CI.md
@@ -1,0 +1,123 @@
+# Excel/VBA Regression CI
+
+This repository can execute the complete VBA regression harness through Microsoft Excel on a self-hosted Windows GitHub Actions runner.
+
+The workflow is defined in `.github/workflows/excel-vba-regression.yml` and invokes `ci/Run-ExcelVbaTests.ps1`.
+
+## Requirements
+
+- A dedicated Windows machine or VM
+- Desktop Microsoft Excel installed and activated
+- A self-hosted GitHub Actions runner labeled `excel`
+- Excel Trust Center setting **Trust access to the VBA project object model** enabled for the runner account
+- An interactive logged-in Windows session for reliable Office COM automation
+
+GitHub-hosted `windows-latest` runners do not include Excel, so this workflow cannot use a standard hosted runner.
+
+## Execution model
+
+For each run, the PowerShell script:
+
+1. creates an isolated Excel COM instance;
+2. creates a temporary macro-enabled workbook;
+3. imports the current modules from `src/`;
+4. imports `tests/M_STATS_PROBDIST_TEST.bas`;
+5. injects a CI-only bridge into the test module;
+6. executes all suites in dependency order;
+7. reads the private assertion counters from inside the same module;
+8. maps the failure count to the PowerShell process exit code;
+9. writes `artifacts/excel-vba-ci/test-result.txt`.
+
+The runtime bridge is not committed to the production test module.
+
+## Runner setup
+
+1. In GitHub, open **Settings > Actions > Runners > New self-hosted runner**.
+2. Install the runner under a dedicated Windows account.
+3. Add the custom label `excel`.
+4. Open Excel once under that account and complete all first-run, activation, privacy and update prompts.
+5. Enable:
+
+```text
+File
+  > Options
+  > Trust Center
+  > Trust Center Settings
+  > Macro Settings
+  > Trust access to the VBA project object model
+```
+
+6. Run the GitHub runner interactively:
+
+```powershell
+.\run.cmd
+```
+
+Microsoft does not recommend unattended Office automation from a non-interactive Windows service. An interactive dedicated session is materially more reliable for Excel COM execution.
+
+## Security model
+
+Self-hosted runners execute repository code with the runner account's permissions. The workflow therefore does not execute pull requests from forks:
+
+```yaml
+if: >-
+  github.event_name != 'pull_request' ||
+  github.event.pull_request.head.repo.full_name == github.repository
+```
+
+For an external contribution, review the changes and copy or cherry-pick them to a maintainer-controlled branch before running the Excel workflow.
+
+Do not switch this workflow to `pull_request_target` for untrusted code.
+
+## Local execution
+
+From a configured Windows/Excel machine:
+
+```powershell
+Set-Location C:\path\to\VBA-PROBABILITY-DISTRIBUTIONS
+.\ci\Run-ExcelVbaTests.ps1
+```
+
+## Result contract
+
+The injected VBA function returns:
+
+```text
+TOTAL=<count>;PASS=<count>;FAIL=<count>
+```
+
+The PowerShell process exits with code `0` only when all assertions pass. Missing modules, VBA compilation failures, Excel automation failures, invalid result counters and test failures all produce exit code `1`.
+
+## Troubleshooting
+
+### Programmatic access denied
+
+Enable **Trust access to the VBA project object model** under the exact Windows account running the self-hosted runner.
+
+### Excel COM class not registered
+
+Confirm that desktop Excel is installed and activated. Repair Office if `New-Object -ComObject Excel.Application` fails.
+
+### Workflow remains queued
+
+Confirm that the runner is online and has all labels:
+
+```text
+self-hosted
+Windows
+X64
+excel
+```
+
+### Orphaned Excel process
+
+Check for modal Excel dialogs, first-run prompts, add-ins, Protected View prompts or Office update dialogs. The script closes the temporary workbook, calls `Excel.Quit()`, releases COM objects and forces finalization, but a modal dialog can still block Office automation.
+
+## Operational controls
+
+- Use a dedicated machine or VM.
+- Limit the runner account's permissions.
+- Keep Windows and Office patched.
+- Do not store unrelated credentials in the account profile.
+- Review workflow changes carefully.
+- Add the Excel regression job as a required branch-protection check after the runner is stable.


### PR DESCRIPTION
## Summary

Adds a self-hosted Windows GitHub Actions workflow that executes the complete VBA regression harness through Microsoft Excel and PowerShell/COM.

## What is included

- `.github/workflows/excel-vba-regression.yml`
  - runs on internal pull requests, pushes to `main`, and manual dispatch;
  - targets a self-hosted Windows runner labeled `excel`;
  - refuses to execute untrusted fork pull-request code;
  - uploads the machine-readable result log.

- `ci/Run-ExcelVbaTests.ps1`
  - creates an isolated temporary `.xlsm` workbook;
  - imports the current production and test `.bas` modules;
  - injects a CI-only bridge into `M_STATS_PROBDIST_TEST` so the existing private counters remain private in source;
  - executes all suites in dependency order;
  - converts `mFailCount` into the PowerShell process exit code;
  - reports compilation, COM, configuration and assertion failures cleanly;
  - closes Excel and releases COM references.

- `docs/EXCEL_VBA_CI.md`
  - documents runner provisioning, Excel Trust Center configuration, interactive runner operation, security controls, local execution and troubleshooting.

## Runner requirement

This workflow requires a self-hosted Windows runner with desktop Microsoft Excel installed and activated. GitHub-hosted Windows runners do not include Excel.

Expected runner labels:

```text
self-hosted
Windows
X64
excel
```

## Security

Fork pull requests are deliberately excluded from the self-hosted job. External changes must first be reviewed and copied to a maintainer-controlled branch before Excel execution.

## Validation status

The workflow and PowerShell script have been structurally reviewed, but cannot execute until a configured Windows/Excel self-hosted runner is online.