### PR TITLE
ci: upgrade GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/accuracy-gate.yml
+++ b/.github/workflows/accuracy-gate.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/excel-vba-regression.yml
+++ b/.github/workflows/excel-vba-regression.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run complete VBA regression suite through Excel COM
         shell: cmd
@@ -50,7 +50,7 @@ jobs:
         
       - name: Upload VBA test result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: excel-vba-regression-${{ github.run_id }}
           path: artifacts/excel-vba-ci/test-result.txt

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create, update, and prune labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
<div align="center">

# 🔀 VBA Probability Distributions Pull Request

</div>

---

## 📌 Summary

Move every GitHub Actions workflow off the deprecated Node 20 runtime onto the current supported Node 24 action majors, so a stable release does not depend on GitHub's compatibility override. No runtime, numerical, or packaged source is touched.

## 🔗 Related issues

```text
Closes #30
```

Acceptance items in #30 that require a hosted or self-hosted run (Accuracy Gate green, Excel VBA Regression reaching the runner, Label Taxonomy Sync dispatch) are verifiable only after this lands on `main`; the closing keyword reflects that the workflow-source work is complete.

## 🧭 Change classification

- [x] Repository tooling, workflow, or governance change

## 🎚️ Affected surface

- [x] No runtime or supported surface — documentation/repository-only

---

## 📐 Scope and contract impact

### In scope

- Bump action majors across all three workflows to Node 24 runtimes.

### Out of scope

- Any change to Python version, runner labels, permissions, path filters, concurrency, or artifact retention.

### Supported behavior and compatibility

```text
Supported behavior changed:       No
Backward compatible:              Yes
Suggested release impact:         none
New supported members:            none
Removed or renamed members:       none
Changed signatures or defaults:   none
Changed results, errors, state, or side effects: none
Migration required:               none for the library; self-hosted Excel runner must be on a current runner agent for checkout v5+
Known limitation introduced or retained: none
```

### Production source and package

- [x] No production source/package impact.

## 🔧 Implementation notes

```text
Approach and key invariant: bump only the `uses:` major tags; every other key in each workflow is byte-unchanged.
  actions/checkout        v4 -> v7  (accuracy-gate, excel-vba-regression, labels-sync)
  actions/setup-python    v5 -> v7  (accuracy-gate)
  actions/upload-artifact v4 -> v7  (excel-vba-regression)
  actions/github-script   v7 -> v9  (labels-sync)
Alternatives considered: pinning the first Node 24 major (checkout v5, setup-python v6, github-script v8) instead of latest; chose the current latest majors per #30's verified reference list.
New dependency, reference, or generated input: none.
State ownership and cleanup: n/a.
Failure behavior: unchanged; fail-closed semantics of each job preserved.
```

Upstream major review (tags verified 2026-09-06 via the actions org tag listings): checkout v7.0.1, setup-python v7.0.0, upload-artifact v7.0.1, github-script v9.0.0 are the current majors and all run on Node 24. No input we use was removed or renamed: checkout is invoked with no inputs; setup-python keeps `python-version: "3.12"`; upload-artifact keeps name/path/if-no-files-found/retention-days; the labels-sync script uses only `github.paginate`, `github.rest.issues.*` and `core.summary`, all stable through github-script v9.

---

## ✅ Verification

### Candidate identity

| Evidence | Result |
| --- | --- |
| Exact PR HEAD SHA | a4480e7a5a9d51b1d248dc8a6281d98515938a4a |
| Base branch and base SHA | main @ a9d47b4a1a80cadaa0031945b102fac891f64566 |
| Working tree used locally | clean |
| Source or package tested | N/A — no executable source changed |

### Static and repository checks

| Check | Result / evidence |
| --- | --- |
| Hosted required checks | NOT RUN — will report on this PR |
| Local static command | YAML parse of all three workflows via PyYAML — PASS |
| Formatting / `git diff --check` | PASS |
| Machine-readable artifact | not produced |

### Excel and VBA execution

- [x] Not required — repository-only change with no executable or packaging impact.

### Validation environment

```text
Excel product, version, and build: N/A
Office bitness:                    N/A
Windows version/build:             N/A
Workbook or add-in host:           N/A
Deployment model:                  N/A
Reference implementation:          N/A
Accuracy grid, holdout set, manifest revision: unchanged
Excel CI or manual host:           N/A
```

### Regression coverage

- [x] No regression change is needed — rationale recorded below.

```text
Coverage rationale and new test names: workflow-runtime metadata only; behavior is exercised by the workflows themselves once they run on main.
Unexecuted or deferred coverage: hosted/self-hosted workflow runs, which execute post-merge.
```

---

## ⚠️ Risk, rollback, and recovery

- [x] Low — mechanically verified metadata change.

```text
Principal failure modes: a bumped action fails to resolve or, for checkout v5+, an out-of-date self-hosted runner agent cannot check out.
Residual risk after validation: self-hosted Excel runner agent version (outside this repo).
Rollback or revert procedure: revert this commit to restore the prior action majors.
Excel-process/workbook/data/artifact recovery: n/a.
Conditions that make rollback unsafe: none.
```

## 🔐 Security, data, and provenance

- [x] No credential, secret, signing material, internal URL, or personal path is included.
- [x] No client, employer, counterparty, student, personal, or restricted production data is included.
- [x] Test data is synthetic, anonymized, or explicitly redistributable.
- [x] External algorithms, code, datasets, and market/vendor data have attributable provenance and compatible licensing.
- [x] Formula, command, path, callback, deserialization, and external-content injection surfaces were assessed.

```text
Security or privacy impact: none. Upgrading to supported runtimes reduces exposure to deprecated Node 20.
Source/data provenance: official actions/* org tags.
New trust boundary: none.
```

## 📚 Documentation and release hygiene

- [x] Version markers remain unchanged unless this is the deliberate release-stamp change.
- [ ] No documentation change is required — reason recorded below.

```text
Documentation impact: none required; workflow files are self-documenting and the upstream review is recorded in the commit message.
Release, artifact, or migration impact: none for the library.
```

---

## 👀 Reviewer focus

```text
Highest-risk decision: jumping to the latest majors (v7/v9) versus the first Node 24 majors.
Files and procedures to inspect first: the three files under .github/workflows.
Evidence to challenge: that no used input was removed across the version jumps.
Known boundary not proved by this pull request: self-hosted Excel runner agent compatibility with checkout v7.
Unresolved question or accepted trade-off: none.
```

## ☑️ Final author check

- [x] The title describes the observable outcome.
- [x] The pull request has one coherent purpose and no unrelated churn.
- [x] Compatibility and release impact are assessed.
- [x] Evidence belongs to the exact candidate claimed.
- [x] The complete diff was reviewed.
- [x] No merge marker, stale placeholder, unexplained N/A, accidental binary, or private material remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFJtmusGS9orotS1Dy93Ro

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFJtmusGS9orotS1Dy93Ro)_